### PR TITLE
Add support for Darwin platform

### DIFF
--- a/keep_alive.go
+++ b/keep_alive.go
@@ -3,8 +3,6 @@ package delugeclient
 import (
 	"fmt"
 	"net"
-	"os"
-	"syscall"
 	"time"
 )
 
@@ -44,18 +42,6 @@ func enableKeepAlive(conn net.Conn, idleTime time.Duration, count int, interval 
 	}*/
 
 	return nil
-}
-
-func setIdle(fd int, secs int) error {
-	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_KEEPIDLE, secs))
-}
-
-func setCount(fd int, n int) error {
-	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_KEEPCNT, n))
-}
-
-func setInterval(fd int, secs int) error {
-	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_KEEPINTVL, secs))
 }
 
 func secs(d time.Duration) int {

--- a/keep_alive_darwin.go
+++ b/keep_alive_darwin.go
@@ -1,0 +1,24 @@
+package delugeclient
+
+import (
+	"os"
+	"syscall"
+)
+
+// from netinet/tcp.h (OS X 10.9.4)
+const (
+	_TCP_KEEPINTVL = 0x101 /* interval between keepalives */
+	_TCP_KEEPCNT   = 0x102 /* number of keepalives before close */
+)
+
+func setIdle(fd int, secs int) error {
+	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_KEEPALIVE, secs))
+}
+
+func setCount(fd int, n int) error {
+	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, _TCP_KEEPCNT, n))
+}
+
+func setInterval(fd int, secs int) error {
+	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, _TCP_KEEPINTVL, secs))
+}

--- a/keep_alive_linux.go
+++ b/keep_alive_linux.go
@@ -1,0 +1,18 @@
+package delugeclient
+
+import (
+	"os"
+	"syscall"
+)
+
+func setIdle(fd int, secs int) error {
+	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_KEEPIDLE, secs))
+}
+
+func setCount(fd int, n int) error {
+	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_KEEPCNT, n))
+}
+
+func setInterval(fd int, secs int) error {
+	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_KEEPINTVL, secs))
+}


### PR DESCRIPTION
Previously, the code in `keep_alive.go` was Linux-specific due to the
constants it used from the 'syscall' package. With this commit, OS-specific
implementations of certain functions have been placed into two files
(`keep_alive_darwin.go` and `keep_alive_linux.go`). This enables the Go
compiler to chose the correct implementation for the current platform at
build-time.

The new Darwin-specific implementation was taken from the
felixge/tcpkeepalive project on GitHub.

Closes #2