### PR TITLE
Add singular 'TorrentStatus' method

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Both deluge v2.0+ and v1.3+ are supported; in order to use the modern deluge v2 
 * [ ] `core.get_proxy`
 * [x] `core.get_session_state`
 * [ ] `core.get_session_status`
-* [ ] `core.get_torrent_status`
+* [x] `core.get_torrent_status`
 * [x] `core.get_torrents_status`
 * [ ] `core.glob`
 * [ ] `core.is_session_paused`

--- a/delugeclient.go
+++ b/delugeclient.go
@@ -50,6 +50,7 @@ type DelugeClient interface {
 	AddTorrentURL(url string, options Options) (string, error)
 	DeleteTorrent(id string) (bool, error)
 	TorrentsStatus() (map[string]*TorrentStatus, error)
+	TorrentStatus(id string) (*TorrentStatus, error)
 	MoveStorage(torrentIDs []string, dest string) error
 	SetTorrentTracker(id, tracker string) error
 	SessionState() ([]string, error)


### PR DESCRIPTION
This PR will add a method with the signature `TorrentStatus(id string) (*TorrentStatus, error)`, which only displays information for a single torrent.

Thanks for considering my changeset. Please let me know if there is anything to fix.