### PR TITLE
Add label support

### DIFF
--- a/delugeclient.go
+++ b/delugeclient.go
@@ -52,6 +52,7 @@ type DelugeClient interface {
 	TorrentsStatus() (map[string]*TorrentStatus, error)
 	MoveStorage(torrentIDs []string, dest string) error
 	SessionState() ([]string, error)
+	SetLabel(hash, label string) error
 }
 
 type NativeDelugeClient interface {
@@ -120,6 +121,7 @@ type TorrentStatus struct {
 	NumPeers            int64
 	NextAnnounce        int64
 	Name                string
+	Label               string
 	State               string
 	TotalSeeds          int64
 	TotalPeers          int64

--- a/methods.go
+++ b/methods.go
@@ -100,6 +100,7 @@ var STATUS_KEYS = rencode.NewList(
 	"tracker_status",
 	"next_announce",
 	"name",
+	"label",
 	"total_size",
 	"progress",
 	"num_seeds",
@@ -230,4 +231,20 @@ func (c *Client) SessionState() ([]string, error) {
 	}
 
 	return result, nil
+}
+
+// SetLabel adds or replaces a label for a torrent with given hash
+func (c *Client) SetLabel(hash, label string) error {
+	var args rencode.List
+	args.Add(hash, label)
+
+	resp, err := c.rpc("label.set_torrent", args, rencode.Dictionary{})
+	if err != nil {
+		return err
+	}
+	if resp.IsError() {
+		return resp.RPCError
+	}
+
+	return nil
 }


### PR DESCRIPTION
This Pull Request adds support for getting and setting label information for torrents.
Labels can contain useful information about a torrent, in form of a single string.

The label attribute is managed by the "label" plugin, which (to my best knowledge) is part of the base installation for the deluge daemon.

The support was tested for version 1.X and version 2 of the daemon.