### PR TITLE
Add SetTorrentTracker method

### DIFF
--- a/delugeclient.go
+++ b/delugeclient.go
@@ -51,6 +51,7 @@ type DelugeClient interface {
 	DeleteTorrent(id string) (bool, error)
 	TorrentsStatus() (map[string]*TorrentStatus, error)
 	MoveStorage(torrentIDs []string, dest string) error
+	SetTorrentTracker(id, tracker string) error
 	SessionState() ([]string, error)
 }
 

--- a/methods.go
+++ b/methods.go
@@ -231,3 +231,28 @@ func (c *Client) SessionState() ([]string, error) {
 
 	return result, nil
 }
+
+// SetTorrentTracker sets the primary tracker for the torrent with the
+// given hash to be `trackerURL`.
+func (c *Client) SetTorrentTracker(id, trackerURL string) error {
+
+	var tracker rencode.Dictionary
+	tracker.Add("url", trackerURL)
+	tracker.Add("tier", 0)
+
+	var trackers rencode.List
+	trackers.Add(tracker)
+
+	var args rencode.List
+	args.Add(id, trackers)
+
+	resp, err := c.rpc("core.set_torrent_trackers", args, rencode.Dictionary{})
+	if err != nil {
+		return err
+	}
+	if resp.IsError() {
+		return resp.RPCError
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds a SetTorrentTracker method with the signature `SetTorrentTracker(id, trackerURL string) error`, which allows automating the update of the primary trackers for added torrents.