### PR TITLE
Accounts methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Both deluge v2.0+ and v1.3+ are supported; in order to use the modern deluge v2 
 * [ ] `core.set_torrent_stop_ratio`
 * [x] `core.set_torrent_trackers`
 * [ ] `core.test_listen_port`
-* [ ] `core.update_account`
+* [x] `core.update_account`
 * [ ] `core.upload_plugin`
 
 ### Plugin methods

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Both deluge v2.0+ and v1.3+ are supported; in order to use the modern deluge v2 
 * [ ] `core.queue_down`
 * [ ] `core.queue_top`
 * [ ] `core.queue_up`
-* [ ] `core.remove_account`
+* [x] `core.remove_account`
 * [x] `core.remove_torrent`
 * [ ] `core.remove_torrents`
 * [ ] `core.rename_files`

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Both deluge v2.0+ and v1.3+ are supported; in order to use the modern deluge v2 
 * [x] `core.add_torrent_magnet`
 * [x] `core.add_torrent_url`
 * [ ] `core.connect_peer`
-* [ ] `core.create_account`
+* [x] `core.create_account`
 * [ ] `core.create_torrent`
 * [ ] `core.disable_plugin`
 * [ ] `core.enable_plugin`

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Both deluge v2.0+ and v1.3+ are supported; in order to use the modern deluge v2 
 * [ ] `core.get_external_ip`
 * [ ] `core.get_filter_tree`
 * [x] `core.get_free_space`
-* [ ] `core.get_known_accounts`
+* [x] `core.get_known_accounts`
 * [ ] `core.get_libtorrent_version`
 * [ ] `core.get_listen_port`
 * [ ] `core.get_path_size`

--- a/account.go
+++ b/account.go
@@ -14,7 +14,9 @@
 
 package delugeclient
 
-import "github.com/gdm85/go-rencode"
+import (
+	"github.com/gdm85/go-rencode"
+)
 
 // Account is a user account inside the auth file.
 type Account struct {
@@ -23,21 +25,21 @@ type Account struct {
 	AuthLevel AuthLevel
 }
 
-func NewAccount(u interface{}) {
+func NewAccount(u interface{}) (*Account, error) {
 	dict, ok := u.(rencode.Dictionary)
 	if !ok {
 		return nil, ErrInvalidListResult
 	}
-	values := dict.Values()
-	if len(values) != 3 {
+	values, err := dict.Zip()
+	if err != nil {
 		return nil, ErrInvalidListResult
 	}
 
 	var a Account
 	//TODO: use keys instead of indexes
-	a.Username = string(values[0].([]byte))
-	a.Password = string(values[1].([]byte))
-	a.AuthLevel = AuthLevel(values[2].([]byte))
+	a.Username = string(values["username"].([]byte))
+	a.Password = string(values["password"].([]byte))
+	a.AuthLevel = AuthLevel(values["authlevel"].([]byte))
 
 	return &a, nil
 }

--- a/account.go
+++ b/account.go
@@ -23,17 +23,29 @@ type Account struct {
 	AuthLevel AuthLevel
 }
 
+func NewAccount(u interface{}) {
+	dict, ok := u.(rencode.Dictionary)
+	if !ok {
+		return nil, ErrInvalidListResult
+	}
+	values := dict.Values()
+	if len(values) != 3 {
+		return nil, ErrInvalidListResult
+	}
+
+	var a Account
+	//TODO: use keys instead of indexes
+	a.Username = string(values[0].([]byte))
+	a.Password = string(values[1].([]byte))
+	a.AuthLevel = AuthLevel(values[2].([]byte))
+
+	return &a, nil
+}
+
 func (a Account) toList() rencode.List {
 	var list rencode.List
 	list.Add(a.Username)
 	list.Add(a.Password)
 	list.Add(string(a.AuthLevel))
 	return list
-}
-
-func (a *Account) fromDictionary(list rencode.Dictionary) {
-	values := list.Values()
-	a.Username = string(values[0].([]byte))
-	a.Password = string(values[1].([]byte))
-	a.AuthLevel = AuthLevel(values[2].([]byte))
 }

--- a/account.go
+++ b/account.go
@@ -1,0 +1,39 @@
+// go-libdeluge v0.3.1 - a native deluge RPC client library
+// Copyright (C) 2015~2019 gdm85 - https://github.com/gdm85/go-libdeluge/
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+package delugeclient
+
+import "github.com/gdm85/go-rencode"
+
+// Account is a user account inside the auth file.
+type Account struct {
+	Username  string
+	Password  string
+	AuthLevel AuthLevel
+}
+
+func (a Account) toList() rencode.List {
+	var list rencode.List
+	list.Add(a.Username)
+	list.Add(a.Password)
+	list.Add(string(a.AuthLevel))
+	return list
+}
+
+func (a *Account) fromDictionary(list rencode.Dictionary) {
+	values := list.Values()
+	a.Username = string(values[0].([]byte))
+	a.Password = string(values[1].([]byte))
+	a.AuthLevel = AuthLevel(values[2].([]byte))
+}

--- a/account.go
+++ b/account.go
@@ -25,7 +25,7 @@ type Account struct {
 	AuthLevel AuthLevel
 }
 
-func(a *Account) fromDictionary(dict rencode.Dictionary) error {
+func (a *Account) fromDictionary(dict rencode.Dictionary) error {
 	values, err := dict.Zip()
 	if err != nil {
 		return err
@@ -34,11 +34,10 @@ func(a *Account) fromDictionary(dict rencode.Dictionary) error {
 		return ErrInvalidReturnValue
 	}
 
-	var a Account
 	a.Username = string(values["username"].([]byte))
 	a.Password = string(values["password"].([]byte))
 	a.AuthLevel = AuthLevel(values["authlevel"].([]byte))
-	
+
 	return nil
 }
 

--- a/account.go
+++ b/account.go
@@ -25,23 +25,21 @@ type Account struct {
 	AuthLevel AuthLevel
 }
 
-func NewAccount(u interface{}) (*Account, error) {
-	dict, ok := u.(rencode.Dictionary)
-	if !ok {
-		return nil, ErrInvalidListResult
-	}
+func(a *Account) fromDictionary(dict rencode.Dictionary) error {
 	values, err := dict.Zip()
 	if err != nil {
-		return nil, ErrInvalidListResult
+		return err
+	}
+	if len(values) < 3 {
+		return ErrInvalidReturnValue
 	}
 
 	var a Account
-	//TODO: use keys instead of indexes
 	a.Username = string(values["username"].([]byte))
 	a.Password = string(values["password"].([]byte))
 	a.AuthLevel = AuthLevel(values["authlevel"].([]byte))
-
-	return &a, nil
+	
+	return nil
 }
 
 func (a Account) toList() rencode.List {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/gdm85/go-libdeluge"
+	delugeclient "github.com/gdm85/go-libdeluge"
 )
 
 var (
@@ -35,6 +35,7 @@ var (
 
 	addURI       string
 	listTorrents bool
+	listAccounts bool
 	v2daemon     bool
 	free         bool
 
@@ -62,6 +63,8 @@ func init() {
 
 	fs.BoolVar(&free, "f", false, "Display free space")
 	fs.BoolVar(&free, "free", false, "Display free space")
+
+	fs.BoolVar(&listAccounts, "list-accounts", false, "List all known user accounts")
 }
 
 func main() {
@@ -173,10 +176,24 @@ func main() {
 			os.Exit(6)
 		}
 
-		b, err := json.MarshalIndent(torrents, "", "\t")
-		if err != nil {
+		je := json.NewEncoder(os.Stdout)
+		je.SetIndent("", "\t")
+		if err := je.Encode(torrents); err != nil {
 			os.Exit(7)
 		}
-		fmt.Println(string(b))
+	}
+
+	if listAccounts {
+		accounts, err := deluge.KnownAccounts()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: could not list all accounts: %v\n", err)
+			os.Exit(6)
+		}
+
+		je := json.NewEncoder(os.Stdout)
+		je.SetIndent("", "\t")
+		if err := je.Encode(accounts); err != nil {
+			os.Exit(7)
+		}
 	}
 }

--- a/delugeclient.go
+++ b/delugeclient.go
@@ -54,8 +54,7 @@ type DelugeClient interface {
 	SetTorrentTracker(id, tracker string) error
 	SessionState() ([]string, error)
 	SetLabel(hash, label string) error
-	CreateAccount(username, password string, authLevel int) (bool, error)
-	UpdateAccount(username, password string, authLevel int) (bool, error)
+	KnownAccounts() ([]string, error)
 	RemoveAccount(username string) (bool, error)
 }
 

--- a/delugeclient.go
+++ b/delugeclient.go
@@ -56,6 +56,7 @@ type DelugeClient interface {
 	SetLabel(hash, label string) error
 	CreateAccount(username, password string, authLevel int) (bool, error)
 	UpdateAccount(username, password string, authLevel int) (bool, error)
+	RemoveAccount(username string) (bool, error)
 }
 
 type NativeDelugeClient interface {

--- a/delugeclient.go
+++ b/delugeclient.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gdm85/go-rencode"
 )
 
-// AuthLevel is a Auth Level string understood by Deluge
+// AuthLevel is an Auth Level string understood by Deluge
 type AuthLevel string
 
 // The auth level names, as defined in

--- a/delugeclient.go
+++ b/delugeclient.go
@@ -67,9 +67,9 @@ type DelugeClient interface {
 	SetTorrentTracker(id, tracker string) error
 	SessionState() ([]string, error)
 	SetLabel(hash, label string) error
-	KnownAccounts() ([]string, error)
-	CreateAccount(username, password string, authLevel AuthLevel) (bool, error)
-	UpdateAccount(username, password string, authLevel AuthLevel) (bool, error)
+	KnownAccounts() ([]Account, error)
+	CreateAccount(account Account) (bool, error)
+	UpdateAccount(account Account) (bool, error)
 	RemoveAccount(username string) (bool, error)
 }
 

--- a/delugeclient.go
+++ b/delugeclient.go
@@ -53,6 +53,7 @@ var (
 	ErrAlreadyClosed      = errors.New("connection is already closed")
 	ErrInvalidListResult  = errors.New("expected dictionary as list response")
 	ErrInvalidReturnValue = errors.New("invalid return value")
+	ErrUnsupported        = errors.New("This method is not supported by your version of the server")
 )
 
 type DelugeClient interface {

--- a/delugeclient.go
+++ b/delugeclient.go
@@ -67,7 +67,7 @@ type DelugeClient interface {
 	SetTorrentTracker(id, tracker string) error
 	SessionState() ([]string, error)
 	SetLabel(hash, label string) error
-	KnownAccounts() ([]Account, error)
+	KnownAccounts() ([]*Account, error)
 	CreateAccount(account Account) (bool, error)
 	UpdateAccount(account Account) (bool, error)
 	RemoveAccount(username string) (bool, error)

--- a/delugeclient.go
+++ b/delugeclient.go
@@ -68,7 +68,7 @@ type DelugeClient interface {
 	SetTorrentTracker(id, tracker string) error
 	SessionState() ([]string, error)
 	SetLabel(hash, label string) error
-	KnownAccounts() ([]*Account, error)
+	KnownAccounts() ([]Account, error)
 	CreateAccount(account Account) (bool, error)
 	UpdateAccount(account Account) (bool, error)
 	RemoveAccount(username string) (bool, error)

--- a/delugeclient.go
+++ b/delugeclient.go
@@ -31,6 +31,19 @@ import (
 	"github.com/gdm85/go-rencode"
 )
 
+// AuthLevel is a Auth Level string understood by Deluge
+type AuthLevel string
+
+// The auth level names, as defined in
+// https://github.com/deluge-torrent/deluge/blob/deluge-2.0.3/deluge/core/authmanager.py#L33-L37
+const (
+	AuthLevelNone     AuthLevel = "NONE"
+	AuthLevelReadonly AuthLevel = "READONLY"
+	AuthLevelNormal   AuthLevel = "NORMAL"
+	AuthLevelAdmin    AuthLevel = "ADMIN"
+	AuthLevelDefault  AuthLevel = AuthLevelNormal
+)
+
 const (
 	DefaultReadWriteTimeout = time.Second * 30
 )
@@ -55,6 +68,8 @@ type DelugeClient interface {
 	SessionState() ([]string, error)
 	SetLabel(hash, label string) error
 	KnownAccounts() ([]string, error)
+	CreateAccount(username, password string, authLevel AuthLevel) (bool, error)
+	UpdateAccount(username, password string, authLevel AuthLevel) (bool, error)
 	RemoveAccount(username string) (bool, error)
 }
 

--- a/delugeclient.go
+++ b/delugeclient.go
@@ -54,6 +54,7 @@ type DelugeClient interface {
 	SetTorrentTracker(id, tracker string) error
 	SessionState() ([]string, error)
 	SetLabel(hash, label string) error
+	CreateAccount(username, password string, authLevel int) (bool, error)
 }
 
 type NativeDelugeClient interface {

--- a/delugeclient.go
+++ b/delugeclient.go
@@ -55,6 +55,7 @@ type DelugeClient interface {
 	SessionState() ([]string, error)
 	SetLabel(hash, label string) error
 	CreateAccount(username, password string, authLevel int) (bool, error)
+	UpdateAccount(username, password string, authLevel int) (bool, error)
 }
 
 type NativeDelugeClient interface {

--- a/delugeclient.go
+++ b/delugeclient.go
@@ -53,7 +53,7 @@ var (
 	ErrAlreadyClosed      = errors.New("connection is already closed")
 	ErrInvalidListResult  = errors.New("expected dictionary as list response")
 	ErrInvalidReturnValue = errors.New("invalid return value")
-	ErrUnsupported        = errors.New("This method is not supported by your version of the server")
+	ErrUnsupported        = errors.New("this method is not supported by your version of the server")
 )
 
 type DelugeClient interface {

--- a/methods.go
+++ b/methods.go
@@ -320,3 +320,26 @@ func (c *Client) UpdateAccount(username, password string, authLevel int) (bool, 
 	return success.(bool), nil
 }
 
+// RemoveAccount will delete an existing username.
+// The authenticated user must have an authLevel of 10 to succeed.
+func (c *Client) RemoveAccount(username string) (bool, error) {
+	var args rencode.List
+	args.Add(username)
+
+	// perform login
+	resp, err := c.rpc("core.remove_account", args, rencode.Dictionary{})
+	if err != nil {
+		return false, err
+	}
+	if resp.IsError() {
+		return false, resp.RPCError
+	}
+
+	vals := resp.returnValue.Values()
+	if len(vals) == 0 {
+		return false, ErrInvalidReturnValue
+	}
+	success := vals[0]
+
+	return success.(bool), nil
+}

--- a/methods.go
+++ b/methods.go
@@ -295,14 +295,20 @@ func (c *Client) KnownAccounts() ([]*Account, error) {
 	}
 
 	// users is now a list of dictionaries, each containing
-	// only one attribute: the username as a bytestring.
+	// three []byte attributes: username, password and auth level
 	var accounts []*Account
 	for _, u := range users.Values() {
-		account, err := NewAccount(u)
+		dict, ok := u.(rencode.Dictionary)
+		if !ok {
+			return nil, ErrInvalidListResult
+		}
+
+		var a Account
+		err := a.fromDictionary(dict)
 		if err != nil {
 			return nil, err
 		}
-		accounts = append(accounts, account)
+		accounts = append(accounts, a)
 	}
 
 	return accounts, nil

--- a/methods.go
+++ b/methods.go
@@ -297,3 +297,26 @@ func (c *Client) CreateAccount(username, password string, authLevel int) (bool, 
 	return success.(bool), nil
 }
 
+// UpdateAccount sets a new password and permission level for a account.
+// The authenticated user must have an authLevel of 10 to succeed.
+func (c *Client) UpdateAccount(username, password string, authLevel int) (bool, error) {
+	var args rencode.List
+	args.Add(username, password, authLevel)
+
+	resp, err := c.rpc("core.update_account", args, rencode.Dictionary{})
+	if err != nil {
+		return false, err
+	}
+	if resp.IsError() {
+		return false, resp.RPCError
+	}
+
+	vals := resp.returnValue.Values()
+	if len(vals) == 0 {
+		return false, ErrInvalidReturnValue
+	}
+	success := vals[0]
+
+	return success.(bool), nil
+}
+

--- a/methods.go
+++ b/methods.go
@@ -288,7 +288,7 @@ func (c *Client) KnownAccounts() ([]string, error) {
 	if err != nil {
 		return []string{}, err
 	}
-	// users  now be a list of dictionaries, which each contain
+	// users now is a list of dictionaries, which each contain
 	// only one attribute: the username as a bytestring.
 
 	result := make([]string, users.Length())

--- a/methods.go
+++ b/methods.go
@@ -305,12 +305,17 @@ func (c *Client) KnownAccounts() ([]string, error) {
 
 // CreateAccount creates a new Deluge user with the supplied username,
 // password and permission level. The authenticated user must have an
-// authLevel 10 to succeed.
-func (c *Client) CreateAccount(username, password string, authLevel int) (bool, error) {
-	var args rencode.List
-	args.Add(username, password, authLevel)
+// authLevel of ADMIN to succeed.
+func (c *Client) CreateAccount(username, password string, authLevel AuthLevel) (bool, error) {
+	var account rencode.List
+	account.Add(username)
+	account.Add(password)
+	account.Add(string(authLevel))
 
-	resp, err := c.rpc("core.create_account", args, rencode.Dictionary{})
+	var args rencode.List
+	args.Add(account)
+
+	resp, err := c.rpc("core.create_account", account, rencode.Dictionary{})
 	if err != nil {
 		return false, err
 	}
@@ -328,10 +333,12 @@ func (c *Client) CreateAccount(username, password string, authLevel int) (bool, 
 }
 
 // UpdateAccount sets a new password and permission level for a account.
-// The authenticated user must have an authLevel of 10 to succeed.
-func (c *Client) UpdateAccount(username, password string, authLevel int) (bool, error) {
+// The authenticated user must have an authLevel of ADMIN to succeed.
+func (c *Client) UpdateAccount(username, password string, authLevel AuthLevel) (bool, error) {
 	var args rencode.List
-	args.Add(username, password, authLevel)
+	args.Add(username)
+	args.Add(password)
+	args.Add(string(authLevel))
 
 	resp, err := c.rpc("core.update_account", args, rencode.Dictionary{})
 	if err != nil {
@@ -351,7 +358,7 @@ func (c *Client) UpdateAccount(username, password string, authLevel int) (bool, 
 }
 
 // RemoveAccount will delete an existing username.
-// The authenticated user must have an authLevel of 10 to succeed.
+// The authenticated user must have an authLevel of ADMIN to succeed.
 func (c *Client) RemoveAccount(username string) (bool, error) {
 	var args rencode.List
 	args.Add(username)

--- a/methods.go
+++ b/methods.go
@@ -272,3 +272,28 @@ func (c *Client) SetLabel(hash, label string) error {
 
 	return nil
 }
+
+// CreateAccount creates a new Deluge user with the supplied username,
+// password and permission level. The authenticated user must have an
+// authLevel 10 to succeed.
+func (c *Client) CreateAccount(username, password string, authLevel int) (bool, error) {
+	var args rencode.List
+	args.Add(username, password, authLevel)
+
+	resp, err := c.rpc("core.create_account", args, rencode.Dictionary{})
+	if err != nil {
+		return false, err
+	}
+	if resp.IsError() {
+		return false, resp.RPCError
+	}
+
+	vals := resp.returnValue.Values()
+	if len(vals) == 0 {
+		return false, ErrInvalidReturnValue
+	}
+	success := vals[0]
+
+	return success.(bool), nil
+}
+

--- a/methods.go
+++ b/methods.go
@@ -308,7 +308,7 @@ func (c *Client) KnownAccounts() ([]*Account, error) {
 		if err != nil {
 			return nil, err
 		}
-		accounts = append(accounts, a)
+		accounts = append(accounts, &a)
 	}
 
 	return accounts, nil

--- a/methods.go
+++ b/methods.go
@@ -275,7 +275,7 @@ func (c *Client) SetLabel(hash, label string) error {
 
 // KnownAccounts returns all known accounts, including password and
 // permission levels.
-func (c *Client) KnownAccounts() ([]*Account, error) {
+func (c *Client) KnownAccounts() ([]Account, error) {
 	if !c.settings.V2Daemon {
 		return nil, ErrUnsupported
 	}
@@ -296,7 +296,7 @@ func (c *Client) KnownAccounts() ([]*Account, error) {
 
 	// users is now a list of dictionaries, each containing
 	// three []byte attributes: username, password and auth level
-	var accounts []*Account
+	var accounts []Account
 	for _, u := range users.Values() {
 		dict, ok := u.(rencode.Dictionary)
 		if !ok {
@@ -308,7 +308,7 @@ func (c *Client) KnownAccounts() ([]*Account, error) {
 		if err != nil {
 			return nil, err
 		}
-		accounts = append(accounts, &a)
+		accounts = append(accounts, a)
 	}
 
 	return accounts, nil

--- a/methods.go
+++ b/methods.go
@@ -276,6 +276,10 @@ func (c *Client) SetLabel(hash, label string) error {
 // KnownAccounts returns all known accounts, including password and
 // permission levels.
 func (c *Client) KnownAccounts() ([]*Account, error) {
+	if !c.settings.V2Daemon {
+		return nil, ErrUnsupported
+	}
+
 	resp, err := c.rpc("core.get_known_accounts", rencode.List{}, rencode.Dictionary{})
 	if err != nil {
 		return nil, err
@@ -294,7 +298,6 @@ func (c *Client) KnownAccounts() ([]*Account, error) {
 	// only one attribute: the username as a bytestring.
 	var accounts []*Account
 	for _, u := range users.Values() {
-		// get each list
 		account, err := NewAccount(u)
 		if err != nil {
 			return nil, err
@@ -309,6 +312,10 @@ func (c *Client) KnownAccounts() ([]*Account, error) {
 // password and permission level. The authenticated user must have an
 // authLevel of ADMIN to succeed.
 func (c *Client) CreateAccount(account Account) (bool, error) {
+	if !c.settings.V2Daemon {
+		return false, ErrUnsupported
+	}
+
 	resp, err := c.rpc("core.create_account", account.toList(), rencode.Dictionary{})
 	if err != nil {
 		return false, err
@@ -329,6 +336,10 @@ func (c *Client) CreateAccount(account Account) (bool, error) {
 // UpdateAccount sets a new password and permission level for a account.
 // The authenticated user must have an authLevel of ADMIN to succeed.
 func (c *Client) UpdateAccount(account Account) (bool, error) {
+	if !c.settings.V2Daemon {
+		return false, ErrUnsupported
+	}
+
 	resp, err := c.rpc("core.update_account", account.toList(), rencode.Dictionary{})
 	if err != nil {
 		return false, err
@@ -349,10 +360,13 @@ func (c *Client) UpdateAccount(account Account) (bool, error) {
 // RemoveAccount will delete an existing username.
 // The authenticated user must have an authLevel of ADMIN to succeed.
 func (c *Client) RemoveAccount(username string) (bool, error) {
+	if !c.settings.V2Daemon {
+		return false, ErrUnsupported
+	}
+
 	var args rencode.List
 	args.Add(username)
 
-	// remove account
 	resp, err := c.rpc("core.remove_account", args, rencode.Dictionary{})
 	if err != nil {
 		return false, err


### PR DESCRIPTION
This PR implements support for creating, updating and deleting accounts by providing a wrapper arount deluge's `core.get_known_accounts`, `core.create_acccount`, `core.update_account`, and `core.remove_account` RPC methods.

I slightly broke convention by not naming the "RemoveAccount" method "DeleteAccount" (as in "DeleteTorrent"), since I believe the method names should be the same as the one that upstream deluge provides.