### PR TITLE
Suggestion: Rename DeleteTorrent to RemoveTorrent

### DIFF
--- a/delugeclient.go
+++ b/delugeclient.go
@@ -48,7 +48,7 @@ type DelugeClient interface {
 	GetFreeSpace(string) (int64, error)
 	AddTorrentMagnet(magnetURI string, options Options) (string, error)
 	AddTorrentURL(url string, options Options) (string, error)
-	RemoveTorrent(id string) (bool, error)
+	RemoveTorrent(id string, rmFiles bool) (bool, error)
 	TorrentsStatus() (map[string]*TorrentStatus, error)
 	MoveStorage(torrentIDs []string, dest string) error
 	SetTorrentTracker(id, tracker string) error

--- a/delugeclient.go
+++ b/delugeclient.go
@@ -48,7 +48,7 @@ type DelugeClient interface {
 	GetFreeSpace(string) (int64, error)
 	AddTorrentMagnet(magnetURI string, options Options) (string, error)
 	AddTorrentURL(url string, options Options) (string, error)
-	DeleteTorrent(id string) (bool, error)
+	RemoveTorrent(id string) (bool, error)
 	TorrentsStatus() (map[string]*TorrentStatus, error)
 	MoveStorage(torrentIDs []string, dest string) error
 	SetTorrentTracker(id, tracker string) error

--- a/methods.go
+++ b/methods.go
@@ -175,13 +175,13 @@ func decodeTorrentsStatusResponse(resp *DelugeResponse) (map[string]*TorrentStat
 
 // DeleteTorrent provides compatibility for the renamed RemoveTorrent method.
 func (c *Client) DeleteTorrent(id string) (bool, error) {
-	return c.RemoveTorrent(id)
+	return c.RemoveTorrent(id, true)
 }
 
 // RemoveTorrent removes a single torrent, returning true if successful.
-func (c *Client) RemoveTorrent(id string) (bool, error) {
+func (c *Client) RemoveTorrent(id string, rmFiles bool) (bool, error) {
 	var args rencode.List
-	args.Add(id, true)
+	args.Add(id, rmFiles)
 
 	// perform login
 	resp, err := c.rpc("core.remove_torrent", args, rencode.Dictionary{})

--- a/methods.go
+++ b/methods.go
@@ -173,11 +173,6 @@ func decodeTorrentsStatusResponse(resp *DelugeResponse) (map[string]*TorrentStat
 	return result, nil
 }
 
-// DeleteTorrent provides compatibility for the renamed RemoveTorrent method.
-func (c *Client) DeleteTorrent(id string) (bool, error) {
-	return c.RemoveTorrent(id, true)
-}
-
 // RemoveTorrent removes a single torrent, returning true if successful.
 func (c *Client) RemoveTorrent(id string, rmFiles bool) (bool, error) {
 	var args rencode.List

--- a/methods.go
+++ b/methods.go
@@ -173,7 +173,13 @@ func decodeTorrentsStatusResponse(resp *DelugeResponse) (map[string]*TorrentStat
 	return result, nil
 }
 
+// DeleteTorrent provides compatibility for the renamed RemoveTorrent method.
 func (c *Client) DeleteTorrent(id string) (bool, error) {
+	return c.RemoveTorrent(id)
+}
+
+// RemoveTorrent removes a single torrent, returning true if successful.
+func (c *Client) RemoveTorrent(id string) (bool, error) {
 	var args rencode.List
 	args.Add(id, true)
 
@@ -186,7 +192,6 @@ func (c *Client) DeleteTorrent(id string) (bool, error) {
 		return false, resp.RPCError
 	}
 
-	// returned hash may be nil if torrent was already added
 	vals := resp.returnValue.Values()
 	if len(vals) == 0 {
 		return false, ErrInvalidReturnValue


### PR DESCRIPTION
In order to be closer to the Method names defined by upstream deluge, I suggest renaming the "DeleteTorrents" method to "RemoveTorrents", while leaving a stub for compatibility in place.