### PR TITLE
Fix headers

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -12,6 +12,7 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+// Command line util to issue requests against a headless deluge server.
 package main
 
 import (

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,18 +1,17 @@
-/*
- * go-libdeluge v0.3.1 - a native deluge RPC client library
- * Copyright (C) 2015~2019 gdm85 - https://github.com/gdm85/go-libdeluge/
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/
+// go-libdeluge v0.3.1 - a native deluge RPC client library
+// Copyright (C) 2015~2019 gdm85 - https://github.com/gdm85/go-libdeluge/
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 package main
 
 import (

--- a/delugeclient.go
+++ b/delugeclient.go
@@ -12,6 +12,8 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+// Package delugeclient allows calling native RPC methods on a remote
+// deluge server.
 package delugeclient
 
 import (
@@ -53,7 +55,7 @@ var (
 	ErrAlreadyClosed      = errors.New("connection is already closed")
 	ErrInvalidListResult  = errors.New("expected dictionary as list response")
 	ErrInvalidReturnValue = errors.New("invalid return value")
-	ErrUnsupportedV1        = errors.New("method not supported by deluge daemon v1")
+	ErrUnsupportedV1      = errors.New("method not supported by deluge daemon v1")
 )
 
 type DelugeClient interface {

--- a/delugeclient.go
+++ b/delugeclient.go
@@ -1,18 +1,17 @@
-/*
- * go-libdeluge v0.3.1 - a native deluge RPC client library
- * Copyright (C) 2015~2019 gdm85 - https://github.com/gdm85/go-libdeluge/
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/
+// go-libdeluge v0.3.1 - a native deluge RPC client library
+// Copyright (C) 2015~2019 gdm85 - https://github.com/gdm85/go-libdeluge/
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 package delugeclient
 
 import (

--- a/delugeclient_test.go
+++ b/delugeclient_test.go
@@ -1,20 +1,18 @@
-package delugeclient
+// go-libdeluge v0.3.1 - a native deluge RPC client library
+// Copyright (C) 2015~2019 gdm85 - https://github.com/gdm85/go-libdeluge/
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-/*
- * go-libdeluge v0.3.1 - a native deluge RPC client library
- * Copyright (C) 2015~2019 gdm85 - https://github.com/gdm85/go-libdeluge/
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/
+package delugeclient
 
 import (
 	"bytes"

--- a/keep_alive.go
+++ b/keep_alive.go
@@ -1,3 +1,17 @@
+// go-libdeluge v0.3.1 - a native deluge RPC client library
+// Copyright (C) 2015~2019 gdm85 - https://github.com/gdm85/go-libdeluge/
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 package delugeclient
 
 import (

--- a/keep_alive_darwin.go
+++ b/keep_alive_darwin.go
@@ -1,3 +1,17 @@
+// go-libdeluge v0.3.1 - a native deluge RPC client library
+// Copyright (C) 2015~2019 gdm85 - https://github.com/gdm85/go-libdeluge/
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 package delugeclient
 
 import (

--- a/keep_alive_linux.go
+++ b/keep_alive_linux.go
@@ -1,3 +1,17 @@
+// go-libdeluge v0.3.1 - a native deluge RPC client library
+// Copyright (C) 2015~2019 gdm85 - https://github.com/gdm85/go-libdeluge/
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 package delugeclient
 
 import (

--- a/methods.go
+++ b/methods.go
@@ -1,18 +1,17 @@
-/*
- * go-libdeluge v0.3.1 - a native deluge RPC client library
- * Copyright (C) 2015~2019 gdm85 - https://github.com/gdm85/go-libdeluge/
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/
+// go-libdeluge v0.3.1 - a native deluge RPC client library
+// Copyright (C) 2015~2019 gdm85 - https://github.com/gdm85/go-libdeluge/
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 package delugeclient
 
 import (

--- a/options_test.go
+++ b/options_test.go
@@ -1,3 +1,17 @@
+// go-libdeluge v0.3.1 - a native deluge RPC client library
+// Copyright (C) 2015~2019 gdm85 - https://github.com/gdm85/go-libdeluge/
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 package delugeclient
 
 import (


### PR DESCRIPTION
This PR prettifies the license headers a little bit. This will cause godoc to be less confused by them.

![image](https://user-images.githubusercontent.com/33927916/70988094-7c099080-20c1-11ea-8ae3-ee9aeeab3051.png)

I also added the headers to files from which they were missing, and added a synopsis that is displayed as a description, when using automatically generated documentation.