### PR TITLE
Implement Pause and Resume methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Both deluge v2.0+ and v1.3+ are supported; in order to use the modern deluge v2 
 * [ ] `core.is_session_paused`
 * [x] `core.move_storage`
 * [ ] `core.pause_session`
-* [ ] `core.pause_torrent`
-* [ ] `core.pause_torrents`
+* [x] `core.pause_torrent`
+* [x] `core.pause_torrents`
 * [ ] `core.prefetch_magnet_metadata`
 * [ ] `core.queue_bottom`
 * [ ] `core.queue_down`
@@ -113,8 +113,8 @@ Both deluge v2.0+ and v1.3+ are supported; in order to use the modern deluge v2 
 * [ ] `core.rename_folder`
 * [ ] `core.rescan_plugins`
 * [ ] `core.resume_session`
-* [ ] `core.resume_torrent`
-* [ ] `core.resume_torrents`
+* [x] `core.resume_torrent`
+* [x] `core.resume_torrents`
 * [ ] `core.set_config`
 * [x] `core.set_torrent_options`
 * [x] `core.set_torrent_trackers`

--- a/delugeclient.go
+++ b/delugeclient.go
@@ -64,6 +64,10 @@ type DelugeClient interface {
 	AddTorrentMagnet(magnetURI string, options *Options) (string, error)
 	AddTorrentURL(url string, options *Options) (string, error)
 	RemoveTorrent(id string, rmFiles bool) (bool, error)
+	PauseTorrents(ids []string) error
+	PauseTorrent(id string) error
+	ResumeTorrents(ids []string) error
+	ResumeTorrent(id string) error
 	TorrentsStatus() (map[string]*TorrentStatus, error)
 	TorrentStatus(id string) (*TorrentStatus, error)
 	MoveStorage(torrentIDs []string, dest string) error

--- a/methods.go
+++ b/methods.go
@@ -228,6 +228,70 @@ func (c *Client) RemoveTorrent(id string, rmFiles bool) (bool, error) {
 	return success.(bool), nil
 }
 
+// PauseTorrents pauses a group of torrents with the given IDs.
+func (c *Client) PauseTorrents(ids []string) error {
+	var args rencode.List
+	args.Add(sliceToRencodeList(ids))
+
+	resp, err := c.rpc("core.pause_torrents", args, rencode.Dictionary{})
+	if err != nil {
+		return err
+	}
+	if resp.IsError() {
+		return resp.RPCError
+	}
+
+	return err
+}
+
+// PauseTorrent pauses a single torrent with the given ID.
+func (c *Client) PauseTorrent(id string) error {
+	var args rencode.List
+	args.Add(id)
+
+	resp, err := c.rpc("core.pause_torrent", args, rencode.Dictionary{})
+	if err != nil {
+		return err
+	}
+	if resp.IsError() {
+		return resp.RPCError
+	}
+
+	return err
+}
+
+// ResumeTorrents unpauses a group of torrents with the given IDs.
+func (c *Client) ResumeTorrents(ids []string) error {
+	var args rencode.List
+	args.Add(sliceToRencodeList(ids))
+
+	resp, err := c.rpc("core.resume_torrents", args, rencode.Dictionary{})
+	if err != nil {
+		return err
+	}
+	if resp.IsError() {
+		return resp.RPCError
+	}
+
+	return err
+}
+
+// ResumeTorrent unpauses a single torrent with the given ID.
+func (c *Client) ResumeTorrent(id string) error {
+	var args rencode.List
+	args.Add(id)
+
+	resp, err := c.rpc("core.resume_torrent", args, rencode.Dictionary{})
+	if err != nil {
+		return err
+	}
+	if resp.IsError() {
+		return resp.RPCError
+	}
+
+	return err
+}
+
 func (c *Client) MoveStorage(torrentIDs []string, dest string) error {
 	var args rencode.List
 	args.Add(sliceToRencodeList(torrentIDs), dest)


### PR DESCRIPTION
This PR implements `core.pause_torrents`, `core.pause_torrent`, `core.resume_torrents` and `core.resume_torrent` RPC methods.

Could not test yet, as currently `rencode.ToSnakeCase` is missing for me, but the code complexity is low and it should work™ :)

I will rebase this for me and report back if it is running.