### PR TITLE
Export added_time attribute

### DIFF
--- a/delugeclient.go
+++ b/delugeclient.go
@@ -133,34 +133,34 @@ type rpcResponseTypeID int
 // The full list of potentially available attributes can be found here:
 // https://github.com/deluge-torrent/deluge/blob/deluge-2.0.3/deluge/core/torrent.py#L1033-L1143
 type TorrentStatus struct {
-	NumSeeds            int64
-	Ratio               float32
-	Progress            float32 // max is 100
-	DistributedCopies   float32
-	TotalDone           int64
-	SeedingTime         int64
-	ETA                 float32 // most times an integer
-	IsFinished          bool
-	NumPieces           int64
-	TrackerHost         string
-	PieceLength         int64
 	ActiveTime          int64
-	IsSeed              bool
-	NumPeers            int64
-	NextAnnounce        int64
-	Name                string
-	Label               string
-	State               string
-	TotalSeeds          int64
-	TotalPeers          int64
-	DownloadPayloadRate int64
-	UploadPayloadRate   int64
-	TrackerStatus       string
-	TotalSize           int64
-	DownloadLocation    string
 	AddedTime           float32 // unix time
 	CompletedTime       int64
+	DistributedCopies   float32
+	DownloadLocation    string
+	DownloadPayloadRate int64
+	ETA                 float32 // most times an integer
+	IsFinished          bool
+	IsSeed              bool
+	Label               string
+	Name                string
+	NextAnnounce        int64
+	NumPeers            int64
+	NumPieces           int64
+	NumSeeds            int64
+	PieceLength         int64
 	Private             bool
+	Progress            float32 // max is 100
+	Ratio               float32
+	SeedingTime         int64
+	State               string
+	TotalDone           int64
+	TotalPeers          int64
+	TotalSeeds          int64
+	TotalSize           int64
+	TrackerHost         string
+	TrackerStatus       string
+	UploadPayloadRate   int64
 
 	Files          []File
 	Peers          []Peer

--- a/delugeclient.go
+++ b/delugeclient.go
@@ -128,6 +128,10 @@ var _ NativeDelugeClient = &Client{}
 
 type rpcResponseTypeID int
 
+// TorrentStatus contains commonly used torrent attributes, as reported
+// by the deluge server.
+// The full list of potentially available attributes can be found here:
+// https://github.com/deluge-torrent/deluge/blob/deluge-2.0.3/deluge/core/torrent.py#L1033-L1143
 type TorrentStatus struct {
 	NumSeeds            int64
 	Ratio               float32
@@ -154,6 +158,7 @@ type TorrentStatus struct {
 	TrackerStatus       string
 	TotalSize           int64
 	DownloadLocation    string
+	AddedTime           float32 // unix time
 	CompletedTime       int64
 	Private             bool
 

--- a/options.go
+++ b/options.go
@@ -11,6 +11,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 package delugeclient
 
 import (


### PR DESCRIPTION
This Pull request adds the added_time attribute to the TorrentStatus struct, exposing it for everyone to use.
I would argue that this field is useful to many users, as it is static, well-suited for indexing and ordering, allowing for queries such as "last 100 torrents" (+pagination), "torrents added since yesterday", "torrents added more than a year ago".

Additionally, the TorrentStatus struct's description now contains a pointer to where new potential attributes can be found.

I took the liberty to sort the field of attributes, to make it more obvious where to potentially add attributes, but please feel free to discard that commit.

I piggyback'd one small change in the options.go, where the license was touching the package name, causing the license to [appear in the package abstract](https://pkg.go.dev/github.com/gdm85/go-libdeluge?tab=doc#pkg-overview), but please feel free to discard that commit.

Thank you for taking the time to read through the PRs and maintain this package.