### PR TITLE
Show SavePath from v1

### DIFF
--- a/torrent_status.go
+++ b/torrent_status.go
@@ -42,6 +42,7 @@ type TorrentStatus struct {
 	NumPieces           int64
 	NumSeeds            int64
 	PieceLength         int64
+	SavePath            string
 	SeedingTime         int64
 	State               string
 	TotalDone           int64
@@ -109,6 +110,7 @@ var statusKeys = rencode.NewList(
 	"time_added",
 	"completed_time",    // v2-only
 	"download_location", // v2-only
+	"save_path",
 	"private")
 
 // TorrentStatus returns the status of the torrent with specified hash.


### PR DESCRIPTION
Hello, 

While building a tool I noticed `download_location` is only for v2 and thus it's empty when using v1api. 
The old `save_path` still exists for `1.3x` and I'd like that added in this package.

Not sure if ``rencode:"v1only"`` is needed or not in the `TorrentStatus` struct.